### PR TITLE
Change event type from tuple to plain object

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ Once you've become familiar with re-frame, feel free to install only the package
 
 @re-frame's API provides the same conceptual ideas as the original re-frame library, with a few name changes to make them more compact and palatable to developers that are used to mobx and redux:
 
-| @re-frame/store API                    | Clojure re-frame API                         |
-| -------------------------------------- | -------------------------------------------- |
-| `store.registerEventDB("id", handler)` | `(re-frame/reg-event-db :id handler)`        |
-| `store.registerEventFX("id", handler)` | `(re-frame/reg-registerEventFX :id handler)` |
-| `store.dispatch(["id", arg])`          | `(re-frame/dispatch [:id arg])`              |
-| `store.computed("id", handler)`        | `(re-frame/reg-sub :id handler)`             |
-| `store.subscribe(["id", arg])`         | `(re-frame/subscribe [:id arg])`             |
-| `store.registerEffect("id", handler)`  | `(re-frame/reg-fx :id handler)`              |
+| @re-frame/store API                    | Clojure re-frame API                  |
+| -------------------------------------- | ------------------------------------- |
+| `store.registerEventDB("id", handler)` | `(re-frame/reg-event-db :id handler)` |
+| `store.registerEventFX("id", handler)` | `(re-frame/reg-event-fx :id handler)` |
+| `store.dispatch({ id: "foo" })`        | `(re-frame/dispatch [:id arg])`       |
+| `store.computed("id", handler)`        | `(re-frame/reg-sub :id handler)`      |
+| `store.subscribe(["id", arg])`         | `(re-frame/subscribe [:id arg])`      |
+| `store.registerEffect("id", handler)`  | `(re-frame/reg-fx :id handler)`       |
 
 Below is an example that shows how to create a store, define event handlers, setup and access subscriptions, and run side effects. For now, you should refer to the original re-frame documentation for best practices.
 
@@ -90,10 +90,10 @@ store.registerEventFX("load-data", (ctx, event) => ({
 }))
 
 // Dispatch events to the store.
-store.dispatch(["init"])      // => count: 0
-store.dispatch(["increment"]) // => count: 1
-store.dispatch(["add", 4])    // => count: 5
-store.dispatch(["load-data"]) // this will start an HTTP request
+store.dispatch({ id: "init" })             // => count: 0
+store.dispatch({ id: "increment" })        // => count: 1
+store.dispatch({ id: "add", payload: 4 })  // => count: 5
+store.dispatch({ id: "load-data" })        // this will start an HTTP request
 ```
 
 While [@re-frame/effects](./packages/effects/README.md) provides numerous built-in effects for you, it's also
@@ -112,7 +112,7 @@ store.registerEventFX("transition", (ctx, event) => ({
   },
   wait: {
     ms: 1000,
-    dispatch: ["finish-transition"],
+    dispatch: { id: "finish-transition" },
   },
 })
 store.registerEventDB("finish-transition", (db, event) => ({
@@ -168,13 +168,13 @@ const ChatList = () => {
 import React from "react"
 import {useDispatch} from "@re-frame/react"
 
-// useDispatch returns a "dispatch" function
-const ChatList = () => {
+const MyComponent = () => {
   const dispatch = useDispatch()
-  const onClick = () => {
-    dispatch(["something-happened"])
-  }
-  // ... more logic here
+  return (
+    <button onClick={() => dispatch({id: "my-event"})}>
+      Click me to trigger "my-event"
+    </button>
+  )
 }
 ```
 

--- a/docs/effects.md
+++ b/docs/effects.md
@@ -19,19 +19,17 @@ store.registerEventFX("load-data", ctx => ({
   http: {
     method: "GET",
     url: "my.api.com/endpoint",
-    success: ["load-data-success"],
-    failure: ["load-data-failure"],
+    success: "load-data-success",
+    failure: "load-data-failure",
   },
 }))
-store.registerEventDB("load-data-success", (db, event) => {
-  const [, response] = event
+store.registerEventDB("load-data-success", (db, {response}) => {
   return {
     loading: false,
     data: response,
   }
 })
-store.registerEventDB("load-data-failure", (db, event) => {
-  const [, error] = event
+store.registerEventDB("load-data-failure", (db, {error}) => {
   return {
     loading: false,
     error,
@@ -50,11 +48,14 @@ store.registerEffect("orchestrate", orchestrate)
 
 store.registerEventFX("boot", () => ({
   orchestrate: {
-    dispatch: ["first-event"],
+    dispatch: {id: "first-event"},
     rules: [
-      {after: "first-event", dispatch: ["second-event"]},
-      {after: "second-event", dispatchN: [["third-event"], ["fourth-event"]]},
-      {after: "third-event", dispatch: ["last-event"], halt: true},
+      {after: "first-event", dispatch: {id: "second-event"}},
+      {
+        after: "second-event",
+        dispatchN: [{id: "third-event"}, {id: "fourth-event"}],
+      },
+      {after: "third-event", dispatch: {id: "last-event"}, halt: true},
     ],
   },
 }))

--- a/packages/effects/lib/http-fx.js
+++ b/packages/effects/lib/http-fx.js
@@ -22,14 +22,16 @@ export function http(store, opts) {
       })
       .then(
         function(res) {
+          // TODO: should merge with config.success if it's an object
           if (config.success) {
-            store.dispatch(config.success.concat(res))
+            store.dispatch({id: config.success, response: res})
           }
           return res
         },
         function(err) {
+          // TODO: should merge with config.failure if it's an object
           if (config.failure) {
-            store.dispatch(config.failure.concat(err))
+            store.dispatch({id: config.failure, error: err})
           } else {
             throw err
           }

--- a/packages/effects/lib/orchestrate-fx.js
+++ b/packages/effects/lib/orchestrate-fx.js
@@ -9,10 +9,9 @@ export function orchestrate(store) {
     }
 
     function postEventCallback(event) {
-      var id = event[0]
       for (var i = 0; i < config.rules.length; i++) {
         var rule = config.rules[i]
-        if (rule.after !== id) continue
+        if (rule.after !== event.id) continue
 
         if (rule.dispatch) {
           store.dispatch(rule.dispatch)

--- a/packages/effects/test/http-fx.spec.js
+++ b/packages/effects/test/http-fx.spec.js
@@ -37,7 +37,7 @@ test("makes a fetch request to config.url", async t => {
   t.deepEqual(fetch.calls, [{arguments: ["/fake-url", {url: "/fake-url"}]}])
 })
 
-test('on "not ok" response, dispatches response as last value in "failure" event', async t => {
+test('on "not ok" response, dispatches response as "error" in "failure" event', async t => {
   const store = makeStore()
   const fetch = spy(() => Promise.resolve(response))
   const response = {
@@ -48,11 +48,13 @@ test('on "not ok" response, dispatches response as last value in "failure" event
   }
 
   const fx = http(store, {fetch})
-  await fx({url: "/fake-url", success: ["on-success"], failure: ["on-failure"]})
-  t.deepEqual(store.dispatch.calls, [{arguments: [["on-failure", response]]}])
+  await fx({url: "/fake-url", success: "on-success", failure: "on-failure"})
+  t.deepEqual(store.dispatch.calls, [
+    {arguments: [{id: "on-failure", error: response}]},
+  ])
 })
 
-test('on "ok" response, dispatches response as last value in "success" event', async t => {
+test('on "ok" response, dispatches response as "response" in "success" event', async t => {
   const store = makeStore()
   const fetch = spy(() => Promise.resolve(response))
   const response = {
@@ -63,8 +65,10 @@ test('on "ok" response, dispatches response as last value in "success" event', a
   }
 
   const fx = http(store, {fetch})
-  await fx({url: "/fake-url", success: ["on-success"]})
-  t.deepEqual(store.dispatch.calls, [{arguments: [["on-success", response]]}])
+  await fx({url: "/fake-url", success: "on-success"})
+  t.deepEqual(store.dispatch.calls, [
+    {arguments: [{id: "on-success", response}]},
+  ])
 })
 
 test('automatically parses json body if content-type matches "application/json"', async t => {
@@ -83,9 +87,9 @@ test('automatically parses json body if content-type matches "application/json"'
   }
 
   const fx = http(store, {fetch})
-  await fx({url: "/fake-url", success: ["on-success"]})
+  await fx({url: "/fake-url", success: "on-success"})
   t.deepEqual(store.dispatch.calls, [
-    {arguments: [["on-success", {mockJsonObject: true}]]},
+    {arguments: [{id: "on-success", response: {mockJsonObject: true}}]},
   ])
 })
 

--- a/packages/interceptors/test/interceptors.spec.js
+++ b/packages/interceptors/test/interceptors.spec.js
@@ -47,54 +47,6 @@ function switchDirections(context) {
   return context
 }
 
-test("payload > strips 'id' from the event", t => {
-  let event
-  const eventSpy = {
-    id: "context-spy",
-    before(context) {
-      event = context.coeffects.event
-      return context
-    },
-  }
-
-  let context = createContext({
-    queue: [payload, eventSpy],
-    effects: {},
-    coeffects: {
-      event: ["add", 5, 6, 7],
-    },
-  })
-  runInterceptors(context)
-  t.deepEqual(event, [5, 6, 7])
-})
-
-test("payload > restores the original event in its 'after' phase", t => {
-  let beforeEvent
-  let afterEvent
-  const eventSpy = {
-    id: "context-spy",
-    before(context) {
-      beforeEvent = context.coeffects.event
-      return context
-    },
-    after(context) {
-      afterEvent = context.coeffects.event
-      return context
-    },
-  }
-
-  let context = createContext({
-    queue: [eventSpy, payload],
-    effects: {},
-    coeffects: {
-      event: ["add", 5],
-    },
-  })
-  context = runInterceptors(context)
-  t.deepEqual(beforeEvent, ["add", 5])
-  t.deepEqual(afterEvent, ["add", 5])
-})
-
 test("path > updates `coeffects.db` to be the value of `db` at `path`", t => {
   let context = createContext({
     queue: [path(["foo", "bar", "baz"])],
@@ -211,7 +163,7 @@ test("validateDB > when the predicate fails, all effects are discarded", t => {
   let context = createContext({
     queue: [validateDB(db => typeof db.count === "number")],
     coeffects: {
-      event: ["bad-event"],
+      event: {id: "bad-event"},
       db: {
         count: 1,
       },
@@ -245,7 +197,7 @@ test('enrich > applies "fn" to "db" effect', t => {
       },
     },
     coeffects: {
-      event: ["noop"],
+      event: {id: "noop"},
     },
   })
   context = runInterceptors(context)
@@ -263,7 +215,7 @@ test('enrich > is ignored if "db" effect does not exist', t => {
       db: {
         count: 1,
       },
-      event: ["noop"],
+      event: {id: "noop"},
     },
   })
   context = runInterceptors(context)
@@ -281,11 +233,11 @@ test('after > runs "fn" as a side-effect against "db" effect', t => {
       },
     },
     coeffects: {
-      event: ["noop"],
+      event: {id: "noop"},
     },
   })
   context = runInterceptors(context)
-  t.deepEqual(calls, [[{count: 1}, ["noop"]]])
+  t.deepEqual(calls, [[{count: 1}, {id: "noop"}]])
 })
 
 test('after > is ignored if "db" effect does not exist', t => {
@@ -295,7 +247,7 @@ test('after > is ignored if "db" effect does not exist', t => {
     queue: [after(fn)],
     effects: {},
     coeffects: {
-      event: ["noop"],
+      event: {id: "noop"},
     },
   })
   context = runInterceptors(context)
@@ -429,7 +381,7 @@ test.only("immer > warns if a draft was created but not returned", t => {
     ],
     coeffects: {
       db,
-      event: ["some-event"],
+      event: {id: "some-event"},
     },
   })
 

--- a/packages/standalone/test/standalone.spec.js
+++ b/packages/standalone/test/standalone.spec.js
@@ -9,10 +9,6 @@ test('exports "path" interceptor', t => {
   t.is(typeof reframe.path, "function")
 })
 
-test('exports "payload" interceptor', t => {
-  t.is(typeof reframe.payload, "object")
-})
-
 test('exports "orchestrate" effect', t => {
   t.is(typeof reframe.orchestrate, "function")
 })

--- a/packages/store/lib/store.js
+++ b/packages/store/lib/store.js
@@ -13,13 +13,12 @@ import {
  * and dispatched events.
  *
  * Once an event is dispatched, the store checks its id and uses that to look
- * up its corresponding event handler. In the example below, "double" is the
- * event id.
+ * up its corresponding event handler.
  *
  * ```js
  * const store = createStore()
- * store.registerEventDB'double', db => db * 2)
- * store.dispatch(['double'])
+ * store.registerEventDB('double', db => db * 2)
+ * store.dispatch({ id: 'double' })
  * ```
  *
  * Here we registered an "EventDB" handler. There's another, higher-level
@@ -37,7 +36,7 @@ import {
  * the two handlers below are functionally equivalent:
  *
  * ```js
- * store.registerEventDB'double-db', db => db * 2)
+ * store.registerEventDB('double-db', db => db * 2)
  * store.registerEventFX('double-fx', ({ db }) => ({
  *  db: db * 2,
  * }))
@@ -77,7 +76,7 @@ export function createStore(opts) {
    * @noreturn
    */
   function processEvent(event) {
-    var interceptors = getRegistration(EVENT, event[0])
+    var interceptors = getRegistration(EVENT, event.id)
     var context = {
       queue: interceptors,
       stack: [],
@@ -257,7 +256,7 @@ export function createStore(opts) {
     after: function after(context) {
       if (!context.effects) {
         if (process.env.NODE_ENV === "development") {
-          var eventId = context.coeffects.event[0]
+          var eventId = context.coeffects.event.id
           console.warn(
             'EventFX "' +
               eventId +
@@ -396,7 +395,7 @@ export function createStore(opts) {
 
   function assertValidEffect(context, effectId) {
     if (!getRegistration(EFFECT, effectId)) {
-      var eventId = context.coeffects.event[0]
+      var eventId = context.coeffects.event.id
       throw new Error(
         'The EventFX handler "' +
           eventId +
@@ -408,17 +407,17 @@ export function createStore(opts) {
   }
 
   function assertValidEvent(event) {
-    if (!Array.isArray(event)) {
+    if (!event || typeof event !== "object" || !event.id) {
       throw new Error(
-        "You dispatched an invalid event. An event is an array that looks like [id] or [id, payload]."
+        'You dispatched an invalid event. An event is an object that has an "id" key.'
       )
     }
-    if (!getRegistration(EVENT, event[0])) {
+    if (!getRegistration(EVENT, event.id)) {
       throw new Error(
         "You dispatched an event that isn't registered with the store. " +
           'Please register "' +
-          event[0] +
-          '" with store.registerEventDB) or store.registerEventFX().'
+          event.id +
+          '" with store.registerEventDB() or store.registerEventFX().'
       )
     }
   }

--- a/packages/store/test/subscriptions.spec.js
+++ b/packages/store/test/subscriptions.spec.js
@@ -10,7 +10,7 @@ function makeStore() {
   const store = createStore()
   store.registerEventDB("init", () => ({count: 0}))
   store.registerEventDB("count", db => ({count: db.count + 1}))
-  store.dispatchSync(["init"])
+  store.dispatchSync({id: "init"})
   return store
 }
 
@@ -38,15 +38,15 @@ test('a top-level subscription is re-run whenever the "db" changes', async t => 
   store.computed("count", db => db.count)
   const sub = store.subscribe(["count"])
 
-  store.dispatch(["count"])
+  store.dispatch({id: "count"})
   await flush()
   t.is(sub.deref(), 1)
 
-  store.dispatch(["count"])
+  store.dispatch({id: "count"})
   await flush()
   t.is(sub.deref(), 2)
 
-  store.dispatch(["count"])
+  store.dispatch({id: "count"})
   await flush()
   t.is(sub.deref(), 3)
 
@@ -62,14 +62,14 @@ test("subscriptions don't notify watchers if their value didn't change", async t
   const sub = store.subscribe(["count"])
   sub.watch(val => history.push(val))
 
-  store.dispatch(["count"])
+  store.dispatch({id: "count"})
   await flush()
   t.deepEqual(history, [1])
-  store.dispatch(["noop"])
-  store.dispatch(["noop"])
+  store.dispatch({id: "noop"})
+  store.dispatch({id: "noop"})
   await flush()
   t.deepEqual(history, [1])
-  store.dispatch(["count"])
+  store.dispatch({id: "count"})
   await flush()
   t.deepEqual(history, [1, 2])
 
@@ -93,7 +93,7 @@ test("simple (no query args) subscriptions are de-duplicated", async t => {
   t.is(sub1, sub3)
   t.is(calls, 1) // subscription handler should only be called once
 
-  store.dispatch(["double"])
+  store.dispatch({id: "double"})
   await flush()
   t.is(calls, 2) // subscription handler should only be called one more time
 
@@ -120,7 +120,7 @@ test("complex (1 or more query args) subscriptions are de-duplicated", async t =
   t.is(sub2, sub3)
   t.is(calls, 2) // once for each unique subscription
 
-  store.dispatch(["double"])
+  store.dispatch({id: "double"})
   await flush()
   t.is(calls, 4) // and again for each unique subscription
 
@@ -144,18 +144,18 @@ test("disposing of a shared subscription only closes the subscription if no more
   t.is(calls, 1)
 
   sub1.dispose()
-  store.dispatch(["double"])
+  store.dispatch({id: "double"})
   await flush()
   t.is(calls, 2)
 
   sub2.dispose()
-  store.dispatch(["double"])
+  store.dispatch({id: "double"})
   await flush()
   t.is(calls, 3)
 
   // Subscription should be inactive after sub3 disposes.
   sub3.dispose()
-  store.dispatch(["double"])
+  store.dispatch({id: "double"})
   await flush()
   t.is(calls, 3) // unchanged from previous test
 })


### PR DESCRIPTION
Change event type from tuple to plain object

1. JavaScript idioms prefer objects over tuples because:
  a. Tuples do not have named components, so their positional values
      convey very limited information, especially with multiple values.

2. Arrays of tuples makes for awkward reading, e.g.:

    ```js
    dispatchN([["foo"], ["bar"], ["baz"]]
    dispatchN([{ id: "foo" }, { id: "bar" }, { id: "baz" }])
    ```

    (Note, there is a plan to support strings in each position, which
    would make both examples equivalent).

    This problem only gets worse if the tuples have collections
    themselves.

3. No standard way to discern common payload interfaces. For example, an
    interceptor may want to intercept every event with an "error" value;
    this is far easier to do with a named value than a positional one.

4. No standard way to attach metadata to events. In JavaScript it's OK
    to attach arbitrary properties to Arrays, but not idiomatic. This is

    Compare:
   
    ```js
    const event = ["foo"]
    event.processedAt = Date.now()
    console.log(event) // ["foo"]

    const event = { id: "foo" }
    event.processedAt = Date.now()
    console.log(event) // { id: "foo", processedAt: <date> }
    ```
